### PR TITLE
Link SQuAD models to all question-answering jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ The table below shows which tasks are currently supported for evaluation in the 
 | `multi_label_classification`    |     ❌     |                                                                                     |
 | `entity_extraction`             |     ✅     | [`eval-staging-838`](https://huggingface.co/datasets/autoevaluate/eval-staging-838) |
 | `extractive_question_answering` |     ✅     |                                                                                     |
-| `translation`                   |     ❌     |                                                                                     |
-| `summarization`                 |     ❌     |                                                                                     |
+| `translation`                   |     ✅     |                                                                                     |
+| `summarization`                 |     ✅     |                                                                                     |

--- a/app.py
+++ b/app.py
@@ -67,6 +67,7 @@ def get_supported_metrics():
         # in the same environment. Refactor to avoid needing to actually load
         # the metric.
         try:
+            print(f"INFO -- Attempting to load metric: {metric}")
             metric_func = load(metric)
         except Exception as e:
             print(e)
@@ -103,7 +104,7 @@ st.markdown(
     Welcome to Hugging Face's automatic model evaluator! This application allows
     you to evaluate 🤗 Transformers
     [models](https://huggingface.co/models?library=transformers&sort=downloads)
-    across a wide variety of datasets on the Hub -- all for free! Please select
+    across a wide variety of datasets on the Hub. Please select
     the dataset and configuration below. The results of your evaluation will be
     displayed on the [public
     leaderboard](https://huggingface.co/spaces/autoevaluate/leaderboards).
@@ -345,8 +346,12 @@ with st.expander("Advanced configuration"):
     )
 
 with st.form(key="form"):
+    # Grab all models fine-tuned on SQuAD for question answering tasks
+    if selected_task == "extractive_question_answering":
+        compatible_models = get_compatible_models(selected_task, [selected_dataset, "squad", "squad_v2"])
+    else:
+        compatible_models = get_compatible_models(selected_task, [selected_dataset])
 
-    compatible_models = get_compatible_models(selected_task, selected_dataset)
     selected_models = st.multiselect(
         "Select the models you wish to evaluate",
         compatible_models,

--- a/app.py
+++ b/app.py
@@ -346,12 +346,7 @@ with st.expander("Advanced configuration"):
     )
 
 with st.form(key="form"):
-    # Grab all models fine-tuned on SQuAD for question answering tasks
-    if selected_task == "extractive_question_answering":
-        compatible_models = get_compatible_models(selected_task, [selected_dataset, "squad", "squad_v2"])
-    else:
-        compatible_models = get_compatible_models(selected_task, [selected_dataset])
-
+    compatible_models = get_compatible_models(selected_task, [selected_dataset])
     selected_models = st.multiselect(
         "Select the models you wish to evaluate",
         compatible_models,

--- a/evaluation.py
+++ b/evaluation.py
@@ -43,7 +43,7 @@ def filter_evaluated_models(models, task, dataset_name, dataset_config, dataset_
         )
         candidate_id = hash(evaluation_info)
         if candidate_id in evaluation_ids:
-            st.info(f"Model {model} has already been evaluated on this configuration. Skipping evaluation...")
+            st.info(f"Model `{model}` has already been evaluated on this configuration. Skipping evaluation...")
             models.pop(idx)
 
     return models

--- a/utils.py
+++ b/utils.py
@@ -75,6 +75,9 @@ def get_compatible_models(task: str, dataset_ids: List[str]) -> List[str]:
     """
     # TODO: relax filter on PyTorch models if TensorFlow supported in AutoTrain
     compatible_models = []
+    if task == "extractive_question_answering":
+        dataset_ids.extend(["squad", "squad_v2"])
+
     for dataset_id in dataset_ids:
         model_filter = ModelFilter(
             task=AUTOTRAIN_TASK_TO_HUB_TASK[task],
@@ -82,7 +85,7 @@ def get_compatible_models(task: str, dataset_ids: List[str]) -> List[str]:
             library=["transformers", "pytorch"],
         )
         compatible_models.extend(HfApi().list_models(filter=model_filter))
-    return sorted([model.modelId for model in compatible_models])
+    return set(sorted([model.modelId for model in compatible_models]))
 
 
 def get_key(col_mapping, val):

--- a/utils.py
+++ b/utils.py
@@ -73,11 +73,13 @@ def get_compatible_models(task: str, dataset_ids: List[str]) -> List[str]:
     Returns:
         A list of model IDs, sorted alphabetically.
     """
-    # TODO: relax filter on PyTorch models if TensorFlow supported in AutoTrain
     compatible_models = []
+    # Include models trained on SQuAD datasets, since these can be evaluated on
+    # other SQuAD-like datasets
     if task == "extractive_question_answering":
         dataset_ids.extend(["squad", "squad_v2"])
 
+    # TODO: relax filter on PyTorch models if TensorFlow supported in AutoTrain
     for dataset_id in dataset_ids:
         model_filter = ModelFilter(
             task=AUTOTRAIN_TASK_TO_HUB_TASK[task],


### PR DESCRIPTION
This PR relaxes the 1 dataset - 1 model constraint for question answering tasks, as these models tend to be fine-tuned on the SQuAD format and can thus be evaluated on any SQuAD-like dataset.

**Caveats**

I haven't done an internal check whether the selected dataset belongs to the SQuAD v1 format (no impossible answers) or the SQuAD v2 format (impossible answers allowed).

Nevertheless, this seems to work across all formats:

* SQuAD v2 model evaluated on v1: https://huggingface.co/huggingface-course/bert-finetuned-squad/discussions/1
* SQuAD v2 model evaluated on SQuAD-like dataset: https://huggingface.co/huggingface-course/bert-finetuned-squad/discussions/3

I think we can leave it like this and see if users report any issues in the evaluations