### PR TITLE
Pin supported metrics and tweak info

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -42,8 +42,8 @@ def filter_evaluated_models(models, task, dataset_name, dataset_config, dataset_
             dataset_split=dataset_split,
         )
         candidate_id = hash(evaluation_info)
-        if candidate_id in evaluation_ids:
-            st.info(f"Model `{model}` has already been evaluated on this configuration. Skipping evaluation...")
-            models.pop(idx)
+        # if candidate_id in evaluation_ids:
+        #     st.info(f"Model `{model}` has already been evaluated on this configuration. Skipping evaluation...")
+        #     models.pop(idx)
 
     return models

--- a/evaluation.py
+++ b/evaluation.py
@@ -42,8 +42,8 @@ def filter_evaluated_models(models, task, dataset_name, dataset_config, dataset_
             dataset_split=dataset_split,
         )
         candidate_id = hash(evaluation_info)
-        # if candidate_id in evaluation_ids:
-        #     st.info(f"Model `{model}` has already been evaluated on this configuration. Skipping evaluation...")
-        #     models.pop(idx)
+        if candidate_id in evaluation_ids:
+            st.info(f"Model `{model}` has already been evaluated on this configuration. Skipping evaluation...")
+            models.pop(idx)
 
     return models

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,5 @@ jsonlines
 # Dataset specific deps
 py7zr<0.19
 openpyxl<3.1
-# Metric specific deps
-scikit-learn<1.2
 # Dirty bug from Google
 protobuf<=3.20.1


### PR DESCRIPTION
This PR does two main things:

* It pins the list of supported metrics to what is currently supported as of today. The `get_supported_metrics()` function relies on having _all_ metric Python dependencies in the same environment, and is very slow. Instead I did a single run offline and added the result in the application itself. We can revisit dynamically listing the supported metrics if https://github.com/huggingface/evaluate/issues/138 becomes available
* Moves the metric info box to the help button to declutter the UI. I've also clarified what is meant by "default arguments"

![Screen Shot 2022-06-17 at 14 21 19](https://user-images.githubusercontent.com/26859204/174297720-8ffedba4-19f1-4ae8-945a-0b5e3a13c426.png)

cc @douwekiela 
